### PR TITLE
link to encrypted, recommended resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # multiple_eventstudy
-Code to produce results in http://dx.doi.org/10.3233/JEM-140383 &amp; http://dx.doi.org/10.2139/ssrn.2341638
+Code to produce results in https://doi.org/10.3233/JEM-140383 &amp; https://doi.org/10.2139/ssrn.2341638


### PR DESCRIPTION
Hello!

The DOI server maybe redirects requests to this old `dx` endpoint, but this PR pre-empts that.
Please see https://www.doi.org/doi_handbook/3_Resolution.html#3.8 and consider updating the links in the repo description here on GitHub as well. Can't include that in the PR, unfortunately.

Cheers :-)